### PR TITLE
switch url for city map tiles to new legion server

### DIFF
--- a/stairdb/static/js/main_map.js
+++ b/stairdb/static/js/main_map.js
@@ -390,7 +390,7 @@ window.addEventListener("map:init", function (event) {
         {maxNativeZoom:18,maxZoom:19,attribution:mbAttributeText}
     );
 
-    var linemap = L.tileLayer('http://stairculture.com/tiles/hk_clr1_2/{z}/{x}/{y}.png',
+    var linemap = L.tileLayer('https://tiles.legiongis.com/hk_clr1_2/{z}/{x}/{y}.png',
         {maxZoom:19}
     );
 


### PR DESCRIPTION
small change to use the new tiles hosting location provided by legion GIS, a good place for long-term tile hosting.